### PR TITLE
Add numpy to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,7 @@ let
     src = lib.cleanSource ./.;
     propagatedBuildInputs = with pkgs.python3.pkgs; [
       appdirs
+      numpy
       pexpect
     ];
   };


### PR DESCRIPTION
This is required to build/run. Also using `buildPythonApplication`, since this
doesn't appear to be a library.