### PR TITLE
default.nix: allow more versatile usage

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,12 @@
-let
-  # pkgs = import <nixpkgs> {};
-  # pkgs = import /home/timo/repos/nixpkgs/root {};
-  pkgs = let
-    # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
-    nixpkgs-rev = "ddf87fb1baf8f5022281dad13fb318fa5c17a7c6";
-  in import (builtins.fetchTarball {
+{ # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  nixpkgs-rev ? "ddf87fb1baf8f5022281dad13fb318fa5c17a7c6"
+, pkgsPath ? builtins.fetchTarball {
     name = "nixpkgs-${nixpkgs-rev}";
     url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs-rev}.tar.gz";
-  }) {};
+  }
+, pkgs ? import pkgsPath {}
+}:
+let
   inherit (pkgs) lib;
   nix-bisect = pkgs.python3.pkgs.buildPythonPackage rec {
     pname = "nix-bisect";


### PR DESCRIPTION
This makes a number of things possible without modifying the
expression (which can be useful when obtaining it from a derivation
like with fetchFromGitHub):

- Use as before with pinned nixpkgs: $(nix-build)
- Override to use any nixpkgs commit:
  `nix-build --argstr nixpkgs-rev ddf87fb1baf8f5022281dad13fb318fa5c17a7c6`
- Use with a local nixpkgs:
  `nix-build --arg pkgsPath '<nixpkgs>'`
  `nix-build --arg pkgsPath ~/nixpkgs`
- Use in a nix expression with an already imported nixpkgs:
  `callPackage /path/to/nix-bisect {}`
  `callPackage (fetchFromGitHub {...}) {}`
  `callPackage (fetchTarball https://github.com/timokau/nix-bisect/archive/master.tar.gz) {}`