### PR TITLE
Fix compatibility with recent Nix

### DIFF
--- a/nix_bisect/nix.py
+++ b/nix_bisect/nix.py
@@ -59,9 +59,9 @@ def build_dry(drvs, nix_options=()):
     to_build = []
     for line in lines:
         line = line.strip()
-        if "these paths will be fetched" in line:
+        if "will be fetched" in line:
             cur = to_fetch
-        elif "these derivations will be built" in line:
+        elif "will be built" in line:
             cur = to_build
         elif line.startswith("/nix/store"):
             cur += [line]


### PR DESCRIPTION
Fixes build_dry() to recognize output like:

    these 16 paths will be fetched (2.98 MiB download, 10.33 MiB unpacked):

and

    this derivation will be built: