### PR TITLE
nix: Fix BuildFailure drvs_failed inconsistency

### DIFF
--- a/nix_bisect/derivation.py
+++ b/nix_bisect/derivation.py
@@ -54,7 +54,7 @@ class Derivation:
         try:
             nix.build(self.immediate_dependencies(), nix_options=self.nix_options)
         except nix.BuildFailure as bf:
-            return bf.drvs_failed[0]
+            return next(iter(bf.drvs_failed))
         return None
 
     def can_build(self):

--- a/nix_bisect/nix.py
+++ b/nix_bisect/nix.py
@@ -3,6 +3,7 @@
 from subprocess import run, PIPE
 import subprocess
 from pathlib import Path
+from typing import Set
 
 import struct
 import signal
@@ -143,7 +144,8 @@ def dependencies(drvs, nix_options=()):
 class BuildFailure(Exception):
     """A failure during build."""
 
-    def __init__(self, drvs_failed):
+    def __init__(self, drvs_failed: Set[str]):
+        assert len(drvs_failed) > 0, "BuildFailure requires at least one derivation to blame."
         super(BuildFailure).__init__()
         self.drvs_failed = drvs_failed
 
@@ -330,7 +332,7 @@ def build(drvs, nix_options=(), use_cache=True, write_cache=True):
             # innocent till proven guilty
             if not result_cache.get(drv, True):
                 print(f"Cached failure of {drv}.")
-                raise BuildFailure([drv])
+                raise BuildFailure(set([drv]))
 
     try:
         return _build_uncached(drvs, nix_options)


### PR DESCRIPTION
The value was only sometimes a list, resulting in the following crash during handling of the BuildFailure exception:

    TypeError: 'set' object is not subscriptable

Let’s always make sure it is a non-empty set and handle it correctly.
