### PR TITLE
Add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695660864,
+        "narHash": "sha256-A8I2YOMa5/AheIC3gNXUWx/Ik3mTKEyeoZIm2btDaaE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "91b7fbbc09aba0b7b70565cffb4b17230e913184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Bisect nix builds.";
+  description = "Bisect nix builds. Flake maintained by @n8henrie.";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,7 @@
         };
 
         apps.${system} =
-          {
-            default = self.apps.${system}.nix-build-status;
-          }
-          // pkgs.lib.genAttrs [
+          pkgs.lib.genAttrs [
             "bisect-env"
             "extra-bisect"
             "nix-build-status"

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,13 @@
   }: let
     inherit (nixpkgs) lib;
     systems = ["aarch64-darwin" "x86_64-linux" "aarch64-linux"];
+
+    # This function build a closure that maps the above systems to a function
+    # accepting a system and returning an attrset in which that system can be
+    # used as `${system}`, making it easy to provide packages / apps / etc.
+    # that apply symmetrically to each of the above systems without having to
+    # repeat oneself. In other words, `packages.${system}.foo = ...` becomes `{
+    # `packages = { system1.foo` = ...; system2.foo = ... };`
     systemClosure = attrs:
       builtins.foldl' (acc: system:
         lib.recursiveUpdate acc (attrs system)) {}

--- a/flake.nix
+++ b/flake.nix
@@ -18,17 +18,20 @@
     # `packages = { system1.foo` = ...; system2.foo = ... };`
     systemClosure = attrs:
       builtins.foldl' (acc: system:
-        lib.recursiveUpdate acc (attrs system)) {}
+        lib.recursiveUpdate
+        acc (attrs system)) {}
       systems;
   in
     systemClosure (
       system: let
-        pkgs = import nixpkgs {inherit system;};
+        pkgs =
+          import nixpkgs {inherit system;};
         pname = "nix-bisect";
       in {
         packages.${system} = {
           default = self.packages.${system}.${pname};
-          ${pname} = pkgs.callPackage ./. {inherit pkgs;};
+          ${pname} =
+            pkgs.callPackage ./. {inherit pkgs;};
         };
 
         apps.${system} =


### PR DESCRIPTION
I realize you're currently [not using flakes](https://github.com/timokau/nix-bisect/issues/23#issuecomment-1576851633), but providing flake outputs sure makes for easy no-install running of these kinds of tools, I'm sure users would appreciate the option:

```console
$ nix run github:n8henrie/nix-bisect -- --help
usage: nix-build-status [-h] [--file FILE] [--option name value] [--argstr name value] [--max-rebuilds MAX_REBUILDS]
                        [--failure-line FAILURE_LINE] [--on-success {good,bad,skip,skip-range,<int>}]
                        [--on-failure {good,bad,skip,skip-range,<int>}]
                        [--on-dependency-failure {good,bad,skip,skip-range,<int>}]
                        [--on-failure-without-line {good,bad,skip,skip-range,<int>}]
                        [--on-instantiation-failure {good,bad,skip,skip-range,<int>}]
                        [--on-resource-limit {good,bad,skip,skip-range,<int>}]
                        [--rebuild-blacklist REBUILD_BLACKLIST]
                        drvish

Build a package with nix, suitable for git-bisect.

positional arguments:
  drvish                Derivation or an attribute/expression that can be resolved to a derivation in the context of
                        the nix file

options:
  -h, --help            show this help message and exit
  --file FILE, -f FILE  Nix file that contains the attribute
  --option name value   Set the Nix configuration option `name` to `value`.
  --argstr name value   Passed on to `nix instantiate`
  --max-rebuilds MAX_REBUILDS
                        Number of builds to allow.
  --failure-line FAILURE_LINE
                        Line required in the build logs to count as a failure.
  --on-success {good,bad,skip,skip-range,<int>}
                        Bisect action if the expression can be successfully built
  --on-failure {good,bad,skip,skip-range,<int>}
                        Bisect action if the expression can be successfully built
  --on-dependency-failure {good,bad,skip,skip-range,<int>}
                        Bisect action if the expression can be successfully built
  --on-failure-without-line {good,bad,skip,skip-range,<int>}
                        Bisect action if the expression can be successfully built
  --on-instantiation-failure {good,bad,skip,skip-range,<int>}
                        Bisect action if the expression cannot be instantiated
  --on-resource-limit {good,bad,skip,skip-range,<int>}
                        Bisect action if a resource limit like rebuild count is exceeded
  --rebuild-blacklist REBUILD_BLACKLIST
                        If any derivation matching this regex needs to be rebuilt, the build is skipped
```

Of course no worries if not interested, thanks for providing the tool in the first place!