### PR TITLE
Refactorings and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,11 @@
 {
   # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
-  nixpkgs-rev ? "ddf87fb1baf8f5022281dad13fb318fa5c17a7c6",
+  # Use the flake.lock nixpkgs revision as the default
+  nixpkgs-rev ?
+    let
+      lockFile = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    lockFile.nodes.nixpkgs.locked.rev,
   pkgsPath ? builtins.fetchTarball {
     name = "nixpkgs-${nixpkgs-rev}";
     url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs-rev}.tar.gz";

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
-{ # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
-  nixpkgs-rev ? "ddf87fb1baf8f5022281dad13fb318fa5c17a7c6"
-, pkgsPath ? builtins.fetchTarball {
+{
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  nixpkgs-rev ? "ddf87fb1baf8f5022281dad13fb318fa5c17a7c6",
+  pkgsPath ? builtins.fetchTarball {
     name = "nixpkgs-${nixpkgs-rev}";
     url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs-rev}.tar.gz";
-  }
-, pkgs ? import pkgsPath {}
+  },
+  pkgs ? import pkgsPath { },
 }:
 let
   inherit (pkgs) lib;
@@ -19,5 +20,5 @@ let
     ];
   };
 in
-  # python3.withPackages(ps: with ps; [nix-bisect])
-  nix-bisect
+# python3.withPackages(ps: with ps; [nix-bisect])
+nix-bisect

--- a/default.nix
+++ b/default.nix
@@ -7,18 +7,5 @@
   },
   pkgs ? import pkgsPath { },
 }:
-let
-  inherit (pkgs) lib;
-  nix-bisect = pkgs.python3.pkgs.buildPythonPackage rec {
-    pname = "nix-bisect";
-    version = "git";
-    src = lib.cleanSource ./.;
-    propagatedBuildInputs = with pkgs.python3.pkgs; [
-      appdirs
-      numpy
-      pexpect
-    ];
-  };
-in
-# python3.withPackages(ps: with ps; [nix-bisect])
-nix-bisect
+
+pkgs.python3.pkgs.callPackage ./package.nix { }

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -18,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "systems": "systems"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712324036,
-        "narHash": "sha256-y9nq45I1EQr4X2pjyJpBV/8TplzWBghj9aeP4tBJCrw=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c606d956be9d7817db5d28150dd31f19202145f",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712163089,
-        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "lastModified": 1713687659,
+        "narHash": "sha256-Yd8KuOBpZ0Slau/NxFhMPJI0gBxeax0vq/FD0rqKwuQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "f2d7a289c5a5ece8521dd082b81ac7e4a57c2c5c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695660864,
-        "narHash": "sha256-A8I2YOMa5/AheIC3gNXUWx/Ik3mTKEyeoZIm2btDaaE=",
+        "lastModified": 1712324036,
+        "narHash": "sha256-y9nq45I1EQr4X2pjyJpBV/8TplzWBghj9aeP4tBJCrw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "91b7fbbc09aba0b7b70565cffb4b17230e913184",
+        "rev": "5c606d956be9d7817db5d28150dd31f19202145f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,40 +2,23 @@
   description = "Bisect nix builds. Flake maintained by @n8henrie.";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.systems.url = "github:nix-systems/default";
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      systems,
-    }:
+    { self, nixpkgs }:
     let
-      inherit (nixpkgs.lib) foldl' recursiveUpdate;
-
-      # This function build a closure that maps the above systems to a function accepting a system
-      # and returning an attrset in which that system can be used as `${system}`, making it easy to
-      # provide packages, apps, and so forth that apply symmetrically to each of the above systems
-      # without having to repeat oneself.
-      #
-      # In other words, `packages.${system}.foo = ...` becomes:
-      # ```nix
-      # {
-      #   packages = {
-      #     system1.foo = ...;
-      #     system2.foo = ...;
-      #   };
-      # }
-      # ```
-      systemClosure =
-        attrs: foldl' (acc: system: recursiveUpdate acc (attrs system)) { } (import systems);
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems f;
     in
-    systemClosure (system: {
-      packages.${system} = {
+    {
+      packages = eachSystem (system: {
         default = self.packages.${system}.nix-bisect;
         nix-bisect = nixpkgs.legacyPackages.${system}.python3.pkgs.callPackage ./package.nix { };
-      };
+      });
 
-      apps.${system} = self.packages.${system}.default.passthru.apps;
-    });
+      apps = eachSystem (system: self.packages.${system}.default.passthru.apps);
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,40 +11,31 @@
       systems,
     }:
     let
-      inherit (nixpkgs.lib) foldl' recursiveUpdate genAttrs;
+      inherit (nixpkgs.lib) foldl' recursiveUpdate;
 
-      # This function build a closure that maps the above systems to a function
-      # accepting a system and returning an attrset in which that system can be
-      # used as `${system}`, making it easy to provide packages / apps / etc.
-      # that apply symmetrically to each of the above systems without having to
-      # repeat oneself. In other words, `packages.${system}.foo = ...` becomes `{
-      # `packages = { system1.foo` = ...; system2.foo = ... };`
+      # This function build a closure that maps the above systems to a function accepting a system
+      # and returning an attrset in which that system can be used as `${system}`, making it easy to
+      # provide packages, apps, and so forth that apply symmetrically to each of the above systems
+      # without having to repeat oneself.
+      #
+      # In other words, `packages.${system}.foo = ...` becomes:
+      # ```nix
+      # {
+      #   packages = {
+      #     system1.foo = ...;
+      #     system2.foo = ...;
+      #   };
+      # }
+      # ```
       systemClosure =
         attrs: foldl' (acc: system: recursiveUpdate acc (attrs system)) { } (import systems);
     in
-    systemClosure (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        pname = "nix-bisect";
-      in
-      {
-        packages.${system} = {
-          default = self.packages.${system}.${pname};
-          ${pname} = pkgs.callPackage ./. { inherit pkgs; };
-        };
+    systemClosure (system: {
+      packages.${system} = {
+        default = self.packages.${system}.nix-bisect;
+        nix-bisect = nixpkgs.legacyPackages.${system}.python3.pkgs.callPackage ./package.nix { };
+      };
 
-        apps.${system} =
-          genAttrs
-            [
-              "bisect-env"
-              "extra-bisect"
-              "nix-build-status"
-            ]
-            (script: {
-              type = "app";
-              program = "${self.packages.${system}.${pname}}/bin/${script}";
-            });
-      }
-    );
+      apps.${system} = self.packages.${system}.default.passthru.apps;
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Bisect nix builds. Flake maintained by @n8henrie.";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/release-23.11";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.systems.url = "github:nix-systems/default";
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -20,5 +20,6 @@
       });
 
       apps = eachSystem (system: self.packages.${system}.default.passthru.apps);
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Bisect nix builds. Flake maintained by @n8henrie.";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/release-23.11";
 
   outputs =
     { self, nixpkgs }:

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Bisect nix builds. Flake maintained by @n8henrie.";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
   outputs =
     { self, nixpkgs }:

--- a/flake.nix
+++ b/flake.nix
@@ -3,47 +3,48 @@
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    inherit (nixpkgs) lib;
-    systems = ["aarch64-darwin" "x86_64-linux" "aarch64-linux"];
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-    # This function build a closure that maps the above systems to a function
-    # accepting a system and returning an attrset in which that system can be
-    # used as `${system}`, making it easy to provide packages / apps / etc.
-    # that apply symmetrically to each of the above systems without having to
-    # repeat oneself. In other words, `packages.${system}.foo = ...` becomes `{
-    # `packages = { system1.foo` = ...; system2.foo = ... };`
-    systemClosure = attrs:
-      builtins.foldl' (acc: system:
-        lib.recursiveUpdate
-        acc (attrs system)) {}
-      systems;
-  in
+      # This function build a closure that maps the above systems to a function
+      # accepting a system and returning an attrset in which that system can be
+      # used as `${system}`, making it easy to provide packages / apps / etc.
+      # that apply symmetrically to each of the above systems without having to
+      # repeat oneself. In other words, `packages.${system}.foo = ...` becomes `{
+      # `packages = { system1.foo` = ...; system2.foo = ... };`
+      systemClosure =
+        attrs: builtins.foldl' (acc: system: lib.recursiveUpdate acc (attrs system)) { } systems;
+    in
     systemClosure (
-      system: let
-        pkgs =
-          import nixpkgs {inherit system;};
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
         pname = "nix-bisect";
-      in {
+      in
+      {
         packages.${system} = {
           default = self.packages.${system}.${pname};
-          ${pname} =
-            pkgs.callPackage ./. {inherit pkgs;};
+          ${pname} = pkgs.callPackage ./. { inherit pkgs; };
         };
 
         apps.${system} =
-          pkgs.lib.genAttrs [
-            "bisect-env"
-            "extra-bisect"
-            "nix-build-status"
-          ]
-          (script: {
-            type = "app";
-            program = "${self.packages.${system}.${pname}}/bin/${script}";
-          });
+          pkgs.lib.genAttrs
+            [
+              "bisect-env"
+              "extra-bisect"
+              "nix-build-status"
+            ]
+            (script: {
+              type = "app";
+              program = "${self.packages.${system}.${pname}}/bin/${script}";
+            });
       }
     );
 }

--- a/package.nix
+++ b/package.nix
@@ -27,6 +27,13 @@ let
       type = "app";
       program = "${self}/bin/${script}";
     });
+
+    meta = {
+      description = "Bisect nix builds";
+      homepage = "https://github.com/timokau/nix-bisect";
+      license = lib.licenses.mit;
+      mainProgram = [ "nix-build-status" ];
+    };
   };
 in
 self

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  appdirs,
+  numpy,
+  pexpect,
+}:
+
+let
+  apps = [
+    "bisect-env"
+    "extra-bisect"
+    "nix-build-status"
+  ];
+  self = buildPythonPackage rec {
+    pname = "nix-bisect";
+    version = "git";
+    src = lib.cleanSource ./.;
+
+    propagatedBuildInputs = [
+      appdirs
+      numpy
+      pexpect
+    ];
+
+    passthru.apps = lib.genAttrs apps (script: {
+      type = "app";
+      program = "${self}/bin/${script}";
+    });
+  };
+in
+self


### PR DESCRIPTION
Hello there! I thought I might provide a few updates and refactorings to this useful set of scripts.

1. Update to `nixfmt-rfc-style` ([RFC 166](https://github.com/NixOS/rfcs/blob/master/rfcs/0166-nix-formatting.md)).
2. Update flake.lock and change the input to nixos-unstable to match default.nix.
3. Create a package.nix and use [`callPackage` style](https://nix.dev/tutorials/callpackage) to inject dependencies.
4. Unify the default revision being used to pull from `flake.lock` (without taking a dependency on flakes themselves.)
5. Move the app definitions into the package, rather than having them be free-floating in the flake. Maybe a new pattern?
6. <del>Use https://github.com/nix-systems/nix-systems to inject the list of systems, so they're externally override-able, rather than encoding that as a list in the flake.</del> Reverted per feedback.
7. Use `nixpkgs.legacyPackages.${system}` in the flake instead of re-importing `nixpkgs` (c.f. https://zimbatm.com/notes/1000-instances-of-nixpkgs)
8. Wired up the formatter value in outputs so that `nix fmt .` works.
9. Added `result*` to `.gitignore` so that `nix build` won't leave untracked files that might accidentally added.