### PR TITLE
Fix nix-build-status with nix 2.15

### DIFF
--- a/nix_bisect/nix.py
+++ b/nix_bisect/nix.py
@@ -159,7 +159,7 @@ def _build_uncached(drvs, nix_options=()):
     # build` will not produce its regular output when it does not detect a tty.
     build_process = pexpect.spawn(
         "nix",
-        ["build", "--no-link"] + _nix_options_to_flags(nix_options) + drvs,
+        ["build", "--no-link"] + _nix_options_to_flags(nix_options) + [d + "^*" if d.endswith(".drv") else d for d in drvs],
         logfile=sys.stdout.buffer,
     )
 


### PR DESCRIPTION
When using `nix build` on `.drv`s, nix 2.15 only builds the drv but not the derivation it refers to.
Fix this by appending `^*` to all drvs to restore the original behavior.

Fixes #25